### PR TITLE
Only check _LogToConsoleIsUsingUnifiedLogging if _LogToConsoleSupportsUnifiedLogging == 1

### DIFF
--- a/Classes/XRLogging.m
+++ b/Classes/XRLogging.m
@@ -117,7 +117,11 @@ NSString * _Nullable _LogToConsoleFormatMessage_v1_arg(LogToConsoleSubsystemType
 
 	NSString *formatString = nil;
 
+#if _LogToConsoleSupportsUnifiedLogging == 1
 	if (_LogToConsoleIsUsingUnifiedLogging == NO) {
+#else
+	if (1) {
+#endif
 	const char *typeString = NULL;
 
 	switch (type) {


### PR DESCRIPTION
Fix a small bug introduced in 9a2561d that prevents compilation when
_LogToConsoleSupportsUnifiedLogging is not enabled.
